### PR TITLE
fix(traefik): use v3.6 for docker api compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   reverse-proxy:
-    image: traefik:v2.5
+    image: traefik:v3.6
     command:
       - "--providers.docker"
       - "--providers.file.directory=/configuration/"


### PR DESCRIPTION
After updating docker on https://recifs.epfl.ch/ host server, we need to update the reverse proxy traefik to v3.6 for docker api compatibility.